### PR TITLE
Fix gender display to show in Japanese (オス, メス, 不明)

### DIFF
--- a/app/models/lost_pet.rb
+++ b/app/models/lost_pet.rb
@@ -1,10 +1,18 @@
 class LostPet < ApplicationRecord
   belongs_to :user
   has_one_attached :image
-  enum gender: { male: 0, female: 1, unknown: 2 }
-
   has_many :lost_pet_comments, dependent: :destroy
-
+  enum gender: { male: 0, female: 1, unknown: 2 }
+    def gender_label
+      case gender
+      when "male"
+        "オス"
+      when "female"
+        "メス"
+      when "unknown"
+        "不明"
+      end
+    end
 end
 
 

--- a/app/views/public/lost_pets/index.html.erb
+++ b/app/views/public/lost_pets/index.html.erb
@@ -28,7 +28,7 @@
                 <h5 class="card-title"><%= lost_pet.title %></h5>
                 <p class="card-text">
                   <strong>名前:</strong> <%= lost_pet.name %><br>
-                  <strong>性別:</strong> <%= lost_pet.gender %><br>
+                  <strong>性別:</strong> <%= lost_pet.gender_label %><br>
                   <strong>種類:</strong> <%= lost_pet.animal_type %><br>               
                   <strong>特徴:</strong> <%= lost_pet.feature %><br>
                   <strong>説明:</strong> <%= lost_pet.description.truncate(100) %><br>


### PR DESCRIPTION
Updated the gender display for lost pets to show in Japanese: "オス", "メス", and "不明".
