### PR TITLE
Fix: Prevent 's' and duplicate text in time ago display

### DIFF
--- a/app/views/public/lost_pets/index.html.erb
+++ b/app/views/public/lost_pets/index.html.erb
@@ -64,8 +64,16 @@
                     <div>
                       <%= link_to lost_pet.user.name, user_path(lost_pet.user), class: "fw-bold d-block" %>
                         <small class="text-muted">
-                          <%= time_ago = time_ago_in_words(lost_pet.created_at)
-                            time_ago.sub('about', '').gsub('days', '日').gsub('day', '日').gsub('hour', '時間').gsub('hours', '時間').gsub('minute', '分').gsub('minutes', '分') + '前に投稿' %>
+                          <% time_ago_raw = time_ago_in_words(lost_pet.created_at) %>
+                          <% formatted_time = time_ago_raw.strip
+                                                          .sub('about', '')
+                                                          .gsub('minutes', '分')
+                                                          .gsub('minute', '分')
+                                                          .gsub('hours', '時間')
+                                                          .gsub('hour', '時間')
+                                                          .gsub('days', '日')
+                                                          .gsub('day', '日') %>
+                          <%= formatted_time + '前に投稿' %>
                         </small>
                     </div>
                   </div>


### PR DESCRIPTION
## Overview

This PR addresses and resolves inconsistencies in the "time ago" display, specifically fixing the presence of leftover "s" (e.g., "minutes") and preventing text duplication in phrases like "about 1 hour ago".

## Changes

The previous display logic for `time_ago_in_words` has been replaced with a refined process that accurately translates and formats the output into natural Japanese. This includes proper handling of whitespace, the "about" prefix, and correct plural-to-singular transformations.

## Verification

Confirmed that time display now appears correctly and consistently (e.g., "2 分前に投稿", "1 時間前に投稿", "3 日前に投稿") without "s" or duplicated text.