### PR TITLE
Feature/public about page

### DIFF
--- a/app/controllers/public/homes_controller.rb
+++ b/app/controllers/public/homes_controller.rb
@@ -1,6 +1,9 @@
 class Public::HomesController < ApplicationController
-    skip_before_action :configure_authentication, only: [:top] 
+    skip_before_action :configure_authentication, only: [:top, :about] 
   
     def top
+    end
+
+    def about
     end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,35 +29,52 @@
           <div class="collapse navbar-collapse" id="navbarNav">
             <ul class="navbar-nav ml-auto">
               <% if user_signed_in? %>
-                <li class="nav-item">
-                  <%= link_to '投稿一覧', posts_path, class: 'nav-link' %>
-                </li>
-              <% unless current_user.guest_user? %>
-                <li class="nav-item">
-                  <%= link_to '新規投稿', new_post_path, class: 'nav-link' %>
-                </li>
-                <li class="nav-item">
-                <%= link_to "いいね一覧", liked_posts_path, class: "nav-link" %>
-                </li>
-              <% end %>
-                <li class="nav-item">
-                  <%= link_to '迷子ペット', lost_pets_path, class: 'nav-link' %>
-                </li>
-              <% unless current_user.guest_user? %>
-                <li class="nav-item">
-                  <%= link_to '迷子ペット投稿', new_lost_pet_path, class: 'nav-link', data: {turbolinks: "false"} %> 
-                </li>
-                <li class="nav-item">
-                  <%= link_to 'マイページ', user_path(current_user), class: 'nav-link' %>
-                </li>
-                <li class="nav-item">
-                  <%= link_to 'about', about_path, class: 'nav-link' %>
-                </li>
-              <% end %>
-                <li class="nav-item">
-                  <%= link_to 'ログアウト', destroy_user_session_path, method: :delete, class: 'nav-link' %>
-                </li>
+                <% if current_user.guest_user? %>
+                  <!-- ゲストログインユーザー -->
+                  <li class="nav-item">
+                    <%= link_to '投稿一覧', posts_path, class: 'nav-link' %>
+                  </li>
+                  <li class="nav-item">
+                    <%= link_to '迷子ペット', lost_pets_path, class: 'nav-link' %>
+                  </li>
+                  <li class="nav-item">
+                    <%= link_to 'About', about_path, class: 'nav-link' %>
+                  </li>
+                  <li class="nav-item">
+                    <%= link_to '新規登録', new_user_registration_path, class: 'nav-link' %>
+                  </li>
+                  <li class="nav-item">
+                    <%= link_to 'ログアウト', destroy_user_session_path, method: :delete, class: 'nav-link' %>
+                  </li>
+                <% else %>
+                  <!-- 通常のログインユーザー -->
+                  <li class="nav-item">
+                    <%= link_to '投稿一覧', posts_path, class: 'nav-link' %>
+                  </li>
+                  <li class="nav-item">
+                    <%= link_to '新規投稿', new_post_path, class: 'nav-link' %>
+                  </li>
+                  <li class="nav-item">
+                    <%= link_to 'いいね一覧', liked_posts_path, class: 'nav-link' %>
+                  </li>
+                  <li class="nav-item">
+                    <%= link_to '迷子ペット', lost_pets_path, class: 'nav-link' %>
+                  </li>
+                  <li class="nav-item">
+                    <%= link_to '迷子ペット投稿', new_lost_pet_path, class: 'nav-link', data: {turbolinks: "false"} %>
+                  </li>
+                  <li class="nav-item">
+                    <%= link_to 'マイページ', user_path(current_user), class: 'nav-link' %>
+                  </li>
+                  <li class="nav-item">
+                    <%= link_to 'About', about_path, class: 'nav-link' %>
+                  </li>
+                  <li class="nav-item">
+                    <%= link_to 'ログアウト', destroy_user_session_path, method: :delete, class: 'nav-link' %>
+                  </li>
+                <% end %>
               <% else %>
+                <!-- ログアウト状態のユーザー -->
                 <li class="nav-item">
                   <%= link_to 'About', about_path, class: 'nav-link' %>
                 </li>
@@ -69,7 +86,7 @@
                 </li>
               <% end %>
             </ul>
-          </div>
+          </div>        
         </div>
       </nav>
     </header>


### PR DESCRIPTION
・Enabled guest users to access the About page by adding the about action.
・Added "About" and "Sign Up" links to the navigation menu for guest users.
・Updated the navigation menu order for guest users to:
Posts → Lost Pets → About → Sign Up → Logout