### PR TITLE
feat: Add 'just now' display for recent posts

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,20 @@
 module ApplicationHelper
+  def custom_posted_time(timestamp)
+    # 投稿されてから60秒未満の場合
+    if (Time.current - timestamp) < 60
+      "たった今投稿"
+    else
+      # 60秒以上の場合
+      time_ago_raw = time_ago_in_words(timestamp)
+      formatted_time = time_ago_raw.strip
+                                    .sub('about', '')
+                                    .gsub('minutes', '分')
+                                    .gsub('minute', '分')
+                                    .gsub('hours', '時間')
+                                    .gsub('hour', '時間')
+                                    .gsub('days', '日')
+                                    .gsub('day', '日')
+      "#{formatted_time}前に投稿"
+    end
+  end
 end

--- a/app/views/public/lost_pets/index.html.erb
+++ b/app/views/public/lost_pets/index.html.erb
@@ -64,16 +64,7 @@
                     <div>
                       <%= link_to lost_pet.user.name, user_path(lost_pet.user), class: "fw-bold d-block" %>
                         <small class="text-muted">
-                          <% time_ago_raw = time_ago_in_words(lost_pet.created_at) %>
-                          <% formatted_time = time_ago_raw.strip
-                                                          .sub('about', '')
-                                                          .gsub('minutes', '分')
-                                                          .gsub('minute', '分')
-                                                          .gsub('hours', '時間')
-                                                          .gsub('hour', '時間')
-                                                          .gsub('days', '日')
-                                                          .gsub('day', '日') %>
-                          <%= formatted_time + '前に投稿' %>
+                          <%= custom_posted_time(lost_pet.created_at) %>
                         </small>
                     </div>
                   </div>


### PR DESCRIPTION
## Overview
Refactored post time display to show "less than a minute ago" (or "just now") for recent posts.

## Changes
Added `custom_posted_time` helper in `application_helper.rb`.
Updated `lost_pets/index.html.erb` to use the new helper.

## How to Test
Verify new posts immediately show "less than a minute ago" and update correctly after 1 minute.