### PR TITLE
Fix: Handle nil missing_date in lost pet display

### DIFF
--- a/app/models/lost_pet.rb
+++ b/app/models/lost_pet.rb
@@ -20,6 +20,7 @@ class LostPet < ApplicationRecord
   end
 
   validates :address, presence: true
+  validates :missing_date, presence: true
 
   geocoded_by :address
   after_validation :geocode, if: -> { will_save_change_to_address? && address.present? }

--- a/app/views/public/lost_pets/index.html.erb
+++ b/app/views/public/lost_pets/index.html.erb
@@ -51,7 +51,9 @@
                   <% end %>
                 </dd>
                 <dt class="col-4">最終目撃場所:</dt><dd class="col-8"> <%= lost_pet.last_seen_location %></dd>
-                <dt class="col-4">行方不明日:</dt><dd class="col-8"> <%= lost_pet.missing_date.strftime('%Y年%m月%d日') %></dd>
+                <dt class="col-4">行方不明日:</dt><dd class="col-8">
+                  <%= lost_pet.missing_date.present? ? lost_pet.missing_date.strftime('%Y年%m月%d日') : '未入力' %>
+                </dd>
                 <dt class="col-4">位置情報:</dt><dd class="col-8"> <%= lost_pet.address %></dd>
                 <dt class="col-4">ステータス:</dt><dd class="col-8"> <%= lost_pet.status == 0 ? '未発見' : '発見' %></dd>
                 <dt class="col-4">💬 コメント数:</dt><dd class="col-8"> <%= lost_pet.lost_pet_comments.count %> 件</dd>


### PR DESCRIPTION
##Overview

Fixes a NoMethodError on the lost pet list page that occurred when the "date missing" was blank.

##Changes

app/views/public/lost_pets/index.html.erb: Added a conditional to display "Not entered" if missing_date is empty, preventing errors.
app/models/lost_pet.rb: Added presence: true validation to missing_date to ensure it's always required going forward.
##Testing

Dates display correctly when entered.
"Not entered" displays without errors when the date is missing.